### PR TITLE
Bug fix for clearing stats

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -53,6 +53,12 @@ TabStats.clearTotalDeleted = function() {
     TabStats.updateRender();
 };
 
+TabStats.clearTotalCreated = function() {
+    TabStats.Storage.stats.totals.created = 0;
+    TabStats.saveStats();
+    TabStats.updateRender();
+};
+
 TabStats.clearLongestTab = function() {
     TabStats.Storage.stats.longest = tabStatsStorage.stats.longest;
     TabStats.saveStats();

--- a/js/popup.js
+++ b/js/popup.js
@@ -29,7 +29,10 @@ function setupEventListeners() {
     document.getElementById("showDeleted").addEventListener("click", showDeleted, false);
 	document.getElementById("showMuted").addEventListener("click", showMuted, false);
 	document.getElementById("exportStats").addEventListener("click", exportStats, false);
+
+	// Clear stats
 	document.getElementById("deletedReset").addEventListener("click", deletedReset, false);
+	document.getElementById("createdReset").addEventListener("click", createdReset, false);
 	document.getElementById("longestReset").addEventListener("click", longestReset, false);
 	document.getElementById("clearAllStats").addEventListener("click", clearAllStats, false);
 }
@@ -53,15 +56,24 @@ function updateDupCount() {
 
 function clearAllStats() {
     TabStats.resetStats();
-    TabStats.updateRender();
+    renderPopupStats();
 }
 
 function deletedReset() {
 	TabStats.clearTotalDeleted();
+	document.getElementById('totalDeleted').innerHTML = TabStats.Storage.stats.totals.deleted || 0;
+	renderPopupStats();
+}
+
+function createdReset() {
+	TabStats.clearTotalCreated();
+	document.getElementById('totalCreated').innerHTML = TabStats.Storage.stats.totals.created || 0;
+	renderPopupStats();
 }
 
 function longestReset() {
     TabStats.clearLongestTab();
+	renderPopupStats();
 }
 
 function renderPopupStats() {

--- a/views/popup.html
+++ b/views/popup.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="/css/popup.css" />
         <script src="/js/popup.js"></script>
     </head>
-    <body>
+    <body id="dragarea">
         <div class="wrapper">
             <h1>Tab Stats</h1>
             <ul class="stat-list">
@@ -17,7 +17,7 @@
                 <li class="stat-list__item"><span class="stat-list__value muted stat-val" id="incognitoCount">0</span> Incognito</li>
                 <li class="stat-list__item">&nbsp;</li>
                 <li class="stat-list__item"><h2>Total</h2></li>
-                <li class="stat-list__item"><span class="stat-list__value created stat-val" id="totalCreated">0</span> Created&nbsp;<a class="resetBtn" href="#" id="deletedReset">X</a></li>
+                <li class="stat-list__item"><span class="stat-list__value created stat-val" id="totalCreated">0</span> Created&nbsp;<a class="resetBtn" href="#" id="createdReset">X</a></li>
                 <li class="stat-list__item"><span class="stat-list__value deleted stat-val" id="totalDeleted">0</span> Deleted&nbsp;<a class="resetBtn" href="#" id="deletedReset">X</a></li>
                 <li class="stat-list__item"><span class="stat-list__value duplicate stat-val" id="duplicateTotalCount">0</span> Duplicate</li>
                 <li class="stat-list__item"><span class="stat-list__value muted stat-val" id="mutedTotalCount">0</span> Muted</li>
@@ -35,8 +35,7 @@
             </div>
 
             <div id="stat-controls" class="stat-controls">
-                <a id="exportStats" href="#">Export Stats</a>
-                <a id="clearAllStats" href="#">Clear all stats</a>
+                <a id="exportStats" href="#">Export</a>, <a id="importStats" href="#">Import</a> or <a id="clearAllStats" href="#">Reset</a> Stats
             </div>
             <p class="author">Created by <a href="http://www.johnakerman.co.uk" target="_blank">John</a> and <a href="http://mabportfolio.com/">Matthew</a></p>
         </div>


### PR DESCRIPTION
This fixes a bug which would clear the deleted amount instead of the created count. It also updates the popup rendering straight away rather than requiring a popup close and open.